### PR TITLE
Fix host driver build failure due to missing includes

### DIFF
--- a/host/include/uhd/cal/database.hpp
+++ b/host/include/uhd/cal/database.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <cstdint>
 
 namespace uhd { namespace usrp { namespace cal {
 

--- a/host/include/uhd/rfnoc/defaults.hpp
+++ b/host/include/uhd/rfnoc/defaults.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace uhd { namespace rfnoc {
 

--- a/host/include/uhd/types/eeprom.hpp
+++ b/host/include/uhd/types/eeprom.hpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace uhd {
 

--- a/host/lib/utils/serial_number.cpp
+++ b/host/lib/utils/serial_number.cpp
@@ -7,6 +7,7 @@
 #include <uhdlib/utils/serial_number.hpp>
 #include <stdexcept>
 #include <string>
+#include <cstdint>
 
 namespace uhd { namespace utils {
    bool serial_numbers_match(const std::string& serial_a, const std::string& serial_b)


### PR DESCRIPTION
Host driver fails to compile on the latest master:

```
[ 10%] Building CXX object lib/CMakeFiles/uhd.dir/cal/database.cpp.o
In file included from /home/tyrell/Coding/antsdr_uhd/host/lib/cal/database.cpp:7:
/home/tyrell/Coding/antsdr_uhd/host/include/uhd/cal/database.hpp:86:24: error: ‘uint8_t’ was not declared in this scope
   86 |     static std::vector<uint8_t> read_cal_data(const std::string& key,
      |                        ^~~~~~~
```